### PR TITLE
Feature/injected api token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ MONTHLY_RECEIPT_REMINDER_DAY=19 #день для даты ежемесячног
 
 BOT_PERSISTENCE_FILE=bot_persistence_file # имя файла persistence бота
 
+SITE_API_BOT_TOKEN=3422b448-2460-4fd2-9183-8000de6f8343 # Токен(uuid) для идентификации бота на сайте.
 SITE_API_URL=http://example.url # адрес сервера, к которому будет отправлять запросы АПИ клиент
 IS_FAKE_API=True # флаг, определяющий какой АПИ клиент используется - боевой или "заглушка", отдающая фейковые данные
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 from datetime import datetime
 from pathlib import Path
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 from datetime import datetime
 from pathlib import Path
 
@@ -29,10 +30,7 @@ def get_datetime_tuple(setting: str) -> tuple:
 
 
 def get_bool(setting: str) -> bool:
-    if env.get(setting) == "True":
-        return True
-    else:
-        return False
+    return env.get(setting) == "True"
 
 
 LOG_NAME = get_string("LOG_NAME")
@@ -62,6 +60,7 @@ URL_SERVICE_RULES = get_string("URL_SERVICE_RULES")
 BOT_PERSISTENCE_FILE = get_string("BOT_PERSISTENCE_FILE")  # имя файла persistence бота
 IS_FAKE_API = get_bool("IS_FAKE_API")  # флаг, определяющий какой АПИ клиент используется - боевой или "заглушка"
 SITE_API_URL = get_string("SITE_API_URL")  # адрес сервера, к которому будет отправлять запросы АПИ клиент
+SITE_API_BOT_TOKEN = get_string("SITE_API_BOT_TOKEN")
 
 TRELLO_API_KEY = get_string("TRELLO_API_KEY")  # API ключ разработчика
 TRELLO_ID_MODEL = get_string("TRELLO_ID_MODEL")  # id таблицы, к которой будет привязан webhook

--- a/src/service/api_client/site_api_service.py
+++ b/src/service/api_client/site_api_service.py
@@ -1,9 +1,10 @@
 import httpx
-from typing import Optional
 
 from core import config
 from service.api_client.base import AbstractAPIService
 from service.api_client.models import BillStat, MonthStat, UserData, UserMonthStat, UserWeekStat, WeekStat
+
+REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": config.SITE_API_BOT_TOKEN}
 
 
 class SiteAPIService(AbstractAPIService):
@@ -18,8 +19,8 @@ class SiteAPIService(AbstractAPIService):
         pass
 
     async def get_week_stat(self) -> list[WeekStat]:
-        url = f"{self.site_url}/tgbot/stat/weekly"
-        async with httpx.AsyncClient() as client:
+        url = "stat/weekly"
+        async with httpx.AsyncClient(**REQUEST_ATTRS) as client:
             response = await client.get(url)
             response = await response.json()
             return [
@@ -46,7 +47,7 @@ class SiteAPIService(AbstractAPIService):
     async def get_user_month_stat(self, telegram_id: int) -> UserMonthStat:
         pass
 
-    async def authenticate_user(self, telegram_id: int) -> Optional[UserData]:
+    async def authenticate_user(self, telegram_id: int) -> UserData | None:
         pass
 
     async def set_user_timezone(self, telegram_id: int, user_time_zone: str) -> httpx:

--- a/src/service/api_client/site_api_service.py
+++ b/src/service/api_client/site_api_service.py
@@ -4,8 +4,6 @@ from core import config
 from service.api_client.base import AbstractAPIService
 from service.api_client.models import BillStat, MonthStat, UserData, UserMonthStat, UserWeekStat, WeekStat
 
-BASE_REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": {"token": config.SITE_API_BOT_TOKEN}}
-
 
 class SiteAPIService(AbstractAPIService):
     """
@@ -14,14 +12,16 @@ class SiteAPIService(AbstractAPIService):
 
     def __init__(self):
         self.site_url: str = config.SITE_API_URL
+        self.bot_token: str = config.SITE_API_BOT_TOKEN
 
     async def get_bill(self) -> BillStat:
         pass
 
     async def get_week_stat(self) -> list[WeekStat]:
-        url = "stat/weekly"
-        async with httpx.AsyncClient(**BASE_REQUEST_ATTRS) as client:
-            response = await client.get(url=url)
+        url = f"{self.site_url}/tgbot/stat/weekly"
+        headers = {"token": self.bot_token}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url=url, headers=headers)
             response = await response.json()
             return [
                 WeekStat(

--- a/src/service/api_client/site_api_service.py
+++ b/src/service/api_client/site_api_service.py
@@ -4,7 +4,7 @@ from core import config
 from service.api_client.base import AbstractAPIService
 from service.api_client.models import BillStat, MonthStat, UserData, UserMonthStat, UserWeekStat, WeekStat
 
-REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": config.SITE_API_BOT_TOKEN}
+REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": {"token": config.SITE_API_BOT_TOKEN}}
 
 
 class SiteAPIService(AbstractAPIService):

--- a/src/service/api_client/site_api_service.py
+++ b/src/service/api_client/site_api_service.py
@@ -4,7 +4,7 @@ from core import config
 from service.api_client.base import AbstractAPIService
 from service.api_client.models import BillStat, MonthStat, UserData, UserMonthStat, UserWeekStat, WeekStat
 
-REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": {"token": config.SITE_API_BOT_TOKEN}}
+BASE_REQUEST_ATTRS = {"base_url": config.SITE_API_URL, "headers": {"token": config.SITE_API_BOT_TOKEN}}
 
 
 class SiteAPIService(AbstractAPIService):
@@ -20,8 +20,8 @@ class SiteAPIService(AbstractAPIService):
 
     async def get_week_stat(self) -> list[WeekStat]:
         url = "stat/weekly"
-        async with httpx.AsyncClient(**REQUEST_ATTRS) as client:
-            response = await client.get(url)
+        async with httpx.AsyncClient(**BASE_REQUEST_ATTRS) as client:
+            response = await client.get(url=url)
             response = await response.json()
             return [
                 WeekStat(


### PR DESCRIPTION
Основная задача: [Авторизация на сервере API через токен](https://www.notion.so/API-701d083489be4954801afd11a16cf3de)
Дополнительно упростил в функции запроса строку с формированием URL, так как httpx при осуществлении запроса всё равно делает `base_url + url`  .
Также убрал `from typing import Optional` , так как в Python 3.10 это не нужно.
Дополнительно `isort` при коммите поправил импорты в затронутых мной файлах.