### PR TITLE
Исправление конкатенации адреса. Ошибки, возникающей в облаке (Webhook)

### DIFF
--- a/src/service/api_client/site_api_service.py
+++ b/src/service/api_client/site_api_service.py
@@ -2,6 +2,7 @@
 import json
 from http import HTTPStatus
 from typing import Optional
+from urllib.parse import urljoin
 
 import httpx
 
@@ -34,7 +35,7 @@ class SiteAPIService(AbstractAPIService):
         ...
 
     async def get_week_stat(self) -> Optional[list[WeekStat]]:
-        url = f"{self.site_url}/tgbot/stat/weekly"
+        url = urljoin(self.site_url, "/tgbot/stat/weekly")
         list_week_stat = await self.__get_json_data(url=url)
         try:
             return [WeekStat.from_dict(one_week_stat) for one_week_stat in list_week_stat]
@@ -43,7 +44,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def get_month_stat(self) -> Optional[list[MonthStat]]:
-        url = f"{self.site_url}/tgbot/stat/monthly"
+        url = urljoin(self.site_url, "/tgbot/stat/monthly")
         list_month_stat = await self.__get_json_data(url=url)
         try:
             return [MonthStat.from_dict(one_month_stat) for one_month_stat in list_month_stat]
@@ -52,7 +53,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def get_user_active_consultations(self, telegram_id: int) -> Optional[UserActiveConsultations]:
-        url = f"{self.site_url}/tgbot/stat/active/user/{telegram_id}"
+        url = urljoin(self.site_url, f"/tgbot/stat/active/user/{telegram_id}")
         active_consultations = await self.__get_json_data(url=url)
         try:
             return UserActiveConsultations.from_dict(active_consultations)
@@ -61,7 +62,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def get_user_expired_consultations(self, telegram_id: int) -> Optional[UserExpiredConsultations]:
-        url = f"{self.site_url}/tgbot/stat/overdue/user/{telegram_id}"
+        url = urljoin(self.site_url, f"/tgbot/stat/overdue/user/{telegram_id}")
         exp_consultations = await self.__get_json_data(url=url)
         try:
             return UserExpiredConsultations.from_dict(exp_consultations)
@@ -70,7 +71,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def get_user_month_stat(self, telegram_id: int) -> Optional[UserMonthStat]:
-        url = f"{self.site_url}/tgbot/stat/monthly/user/{telegram_id}"
+        url = urljoin(self.site_url, f"/tgbot/stat/monthly/user/{telegram_id}")
         user_month_stat = await self.__get_json_data(url=url)
         try:
             return UserMonthStat.from_dict(user_month_stat)
@@ -79,7 +80,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def authenticate_user(self, telegram_id: int) -> Optional[UserData]:
-        url = f"{self.site_url}/tgbot/user/{telegram_id}"
+        url = urljoin(self.site_url, f"/tgbot/user/{telegram_id}")
         user = await self.__get_json_data(url=url)
         try:
             return UserData.from_dict(user)
@@ -88,7 +89,7 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def set_user_timezone(self, telegram_id: int, user_time_zone: str) -> HTTPStatus:
-        url = f"{self.site_url}/tgbot/user"
+        url = urljoin(self.site_url, "/tgbot/user")
         headers = {"Authorization": self.bot_token}
         data = {"telegram_id": telegram_id, "timezone": user_time_zone}
         async with httpx.AsyncClient() as client:
@@ -96,8 +97,8 @@ class SiteAPIService(AbstractAPIService):
             return response.status_code
 
     async def get_daily_consultations(self) -> Optional[list[Consultation]]:
-        url = f"{self.site_url}/tgbot/consultations"
-        consultations = self.__get_json_data(url=url)
+        url = urljoin(self.site_url, "/tgbot/consultations")
+        consultations = await self.__get_json_data(url=url)
         try:
             return [Consultation.from_dict(consultation) for consultation in consultations]
         except TypeError as error:
@@ -105,8 +106,8 @@ class SiteAPIService(AbstractAPIService):
             return None
 
     async def get_consultation(self, consultation_id: int) -> Optional[ConsultationDueDate]:
-        url = f"{self.site_url}/tgbot/consultations/{consultation_id}"
-        consultation = self.__get_json_data(url=url)
+        url = urljoin(self.site_url, f"/tgbot/consultations/{consultation_id}")
+        consultation = await self.__get_json_data(url=url)
         try:
             return ConsultationDueDate.from_dict(consultation)
         except TypeError as error:


### PR DESCRIPTION
Исправление конкатенации адреса - при существующей конкатенации возникал задвоенный слеш в случае указания в параметрах .env адреса со слешем на конце. Был использован urljoin для того, чтобы такой ситуации избежать.
При запуске бота  в режиме Webhook на сервере в облаке возникала ошибка "RuntimeWarning: coroutine 'SiteAPIService.__get_json_data' was never awaited" что указывало на отсутствие await для async метода. 
Так как тестирование проводится в облаке, эти исправления нужно туда запушить. 