### PR TITLE
fix text weekly statistic

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -44,7 +44,9 @@ WEEKLY_STATISTIC_TEMPLATE = (
     "Истекает срок у *{expiring_consultations}* заявок\n"
     "У *{expired_consultations}* заявок срок истек\n\n"
     "[Открыть Trello](https://trello.com/{trello_id}/"
-    "?filter=member:{username_trello}/)\n"
+    "?filter=member:{username_trello}/)\n\n"
+    "Мы рады работать в одной команде :)\n"
+    "Так держать!\n"
 )
 
 MONTHLY_STATISTIC_TEMPLATE = (
@@ -54,7 +56,9 @@ MONTHLY_STATISTIC_TEMPLATE = (
     "{rating}"
     "{average_user_answer_time}\n"
     "[Открыть Trello](https://trello.com/{trello_id}/"
-    "?filter=member:{username_trello}/)\n"
+    "?filter=member:{username_trello}/)\n\n"
+    "Мы рады работать в одной команде :)\n"
+    "Так держать!\n"
 )
 
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"


### PR DESCRIPTION
**Выполнение задачи:**
[Баг] ID-1209.1B | Еженедельное уведомление эксперту в бот https://t.me/nenaprasnoBot со статистикой за прошедшую неделю  не содержит текст: Мы рады работать в одной команде :) Так держать!

_Дополнительно:_
Посмотрев ТЗ с текстами увидела, что данную фразу должно содержать также и ежемесячное уведомление. Поэтому добавила её и в этот шаблон.