### PR TITLE
Changed the start up of the weekly_stat_job, monthly_bill_reminder_job, monthly_stat_job to 00:00 +12, changed the individual jobs start up to the ENV parameters value with timezone

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,6 @@
 from datetime import time, timedelta
 from urllib.parse import urljoin
+from zoneinfo import ZoneInfo
 
 from telegram import Update
 from telegram.ext import (
@@ -72,14 +73,24 @@ def create_bot():
         ]
     )
     # Once per week bot sends current week statistics (default: friday)
-    bot_app.job_queue.run_daily(weekly_stat_job, time=config.WEEKLY_STAT_TIME, days=config.WEEKLY_STAT_WEEK_DAYS)
+    bot_app.job_queue.run_daily(
+        weekly_stat_job,
+        time=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        days=config.WEEKLY_STAT_WEEK_DAYS,
+    )
     # Once per month bot sends bill reminder (default: 1st day of month)
     bot_app.job_queue.run_monthly(
-        monthly_bill_reminder_job, when=config.MONTHLY_RECEIPT_REMINDER_TIME, day=config.MONTHLY_RECEIPT_REMINDER_DAY
+        monthly_bill_reminder_job,
+        when=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        day=config.MONTHLY_RECEIPT_REMINDER_DAY,
     )
 
     # Once per month bot sends previous month statistics
-    bot_app.job_queue.run_monthly(monthly_stat_job, when=config.MONTHLY_STAT_TIME, day=config.MONTHLY_STAT_DAY)
+    bot_app.job_queue.run_monthly(
+        monthly_stat_job,
+        when=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        day=config.MONTHLY_STAT_DAY,
+    )
 
     # Once per day (but for every time zone) bot collects overdue consultations and send reminder
     # Doctor receives reminder at DAILY_OVERDUE_CONSULTATIONS_REMINDER_JOB his time zone

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,6 +1,5 @@
 from datetime import time, timedelta
 from urllib.parse import urljoin
-from zoneinfo import ZoneInfo
 
 from telegram import Update
 from telegram.ext import (
@@ -75,20 +74,20 @@ def create_bot():
     # Once per week bot sends current week statistics (default: friday)
     bot_app.job_queue.run_daily(
         weekly_stat_job,
-        time=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        time=config.STAT_COLLECTION_TIME,
         days=config.WEEKLY_STAT_WEEK_DAYS,
     )
     # Once per month bot sends bill reminder (default: 1st day of month)
     bot_app.job_queue.run_monthly(
         monthly_bill_reminder_job,
-        when=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        when=config.STAT_COLLECTION_TIME,
         day=config.MONTHLY_RECEIPT_REMINDER_DAY,
     )
 
     # Once per month bot sends previous month statistics
     bot_app.job_queue.run_monthly(
         monthly_stat_job,
-        when=time(hour=0, minute=0, second=0, tzinfo=ZoneInfo("Asia/Kamchatka")),
+        when=config.STAT_COLLECTION_TIME,
         day=config.MONTHLY_STAT_DAY,
     )
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime, time, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from dotenv import dotenv_values
 
@@ -73,6 +74,10 @@ MONTHLY_RECEIPT_REMINDER_DAY = get_int("MONTHLY_RECEIPT_REMINDER_DAY", "20")
 # Параметры рассылки напоминаний
 DAILY_COLLECT_CONSULTATIONS_TIME = time(hour=0, minute=0, tzinfo=timezone.utc)
 DAILY_CONSULTATIONS_REMINDER_TIME = get_time("DAILY_CONSULTATIONS_REMINDER_TIME", "17:00")
+
+# Параметры запуска сбора недельной и месячной статистики - по умолчанию, полночь GTM+12
+STAT_COLLECTION_TIMEZONE = "Asia/Kamchatka"
+STAT_COLLECTION_TIME = time(hour=0, minute=0, second=0, tzinfo=ZoneInfo(STAT_COLLECTION_TIMEZONE))
 
 # Файл с сохраненными данными бота
 BOT_PERSISTENCE_FILE = BASE_DIR / "persistence_data" / "bot_persistence_file"

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -156,11 +156,7 @@ async def weekly_stat_job(context: CallbackContext) -> None:
 
     for tz_string in timezones:
         timezone_ = get_timezone_from_str(tz_string)
-        start_time = (
-            timedelta(microseconds=1)
-            if timezone_ == timezone.utc
-            else config.WEEKLY_STAT_TIME.replace(tzinfo=timezone_)
-        )
+        start_time = config.WEEKLY_STAT_TIME.replace(tzinfo=timezone_)
         context.job_queue.run_once(send_weekly_statistic_job, when=start_time, data=tz_string)
 
 
@@ -172,11 +168,7 @@ async def monthly_stat_job(context: CallbackContext) -> None:
         if statistic.telegram_id is None:
             continue
         timezone_ = get_timezone_from_str(statistic.timezone)
-        start_time = (
-            timedelta(microseconds=1)
-            if timezone_ == timezone.utc
-            else config.MONTHLY_STAT_TIME.replace(tzinfo=timezone_)
-        )
+        start_time = config.MONTHLY_STAT_TIME.replace(tzinfo=timezone_)
         context.job_queue.run_once(send_monthly_statistic_job, when=start_time, data=statistic)
 
 


### PR DESCRIPTION
На уровне запуска бота изменено время запуска weekly_stat_job, monthly_bill_reminder_job, monthly_stat_job на полночь на Камчатке (00:00 +12), внутри джобов изменено время запуска индивидульаных джобов на значение параметров из ENV с учетов времнной зоны пользователя