### PR TITLE
Fix/bill riminder buttons

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -32,7 +32,7 @@ from service.repeat_message import repeat_message_after_1_hour_callback
 
 async def skip_bill_callback_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Delete button under message."""
-    await edit_message(update=update, new_text=update.callback_query.message.text_markdown_v2_urled)
+    await edit_message(update, update.callback_query.message.text_markdown_v2_urled)
     await update.callback_query.answer()  # close progress bar in chat
 
 
@@ -44,7 +44,7 @@ async def done_bill_callback_handler(update: Update, context: ContextTypes.DEFAU
     current_jobs = context.job_queue.get_jobs_by_name(job_name)
     for job in current_jobs:
         job.schedule_removal()
-    await edit_message(update=update, new_text="Не будем напоминать до следующего месяца")
+    await edit_message(update, "Не будем напоминать до следующего месяца")
     await query.answer()  # close progress bar in chat
 
 

--- a/src/core/send_message.py
+++ b/src/core/send_message.py
@@ -1,14 +1,11 @@
 import logging
-from string import Template
-from typing import List, Optional
+from typing import Optional
 
 from telegram import Bot, InlineKeyboardMarkup, ReplyKeyboardMarkup, Update
 from telegram.constants import ParseMode
 from telegram.error import Forbidden, TelegramError
-from telegram.ext import CallbackContext
 
 from core.logger import logger
-from service.api_client.models import MonthStat, WeekStat
 
 
 async def send_message(
@@ -55,32 +52,3 @@ async def reply_message(
     except TelegramError:
         logger.exception("The error reply on the message to the chat: %d", update.effective_chat.id)
         return False
-
-
-# is useless now
-async def send_statistics(
-    context: CallbackContext,
-    template_message: Template,
-    template_attribute_aliases: dict,
-    statistic: List[MonthStat | WeekStat],
-    reply_markup: Optional[ReplyKeyboardMarkup | InlineKeyboardMarkup] = None,
-) -> None:
-    """
-    Start mailing message with statistics.
-    :param context: CallbackContext
-    :param template_message: Template
-    :param template_attribute_aliases: dict in this dictionary,
-        the keys are the names of attributes in the message
-        template and the keys are the names of attributes in
-        the data object.
-    :param statistic: List[Union[UserMonthStat, UserWeekStat]]
-    :param reply_markup: ReplyKeyboardMarkup | None
-    """
-    for user_statistic in statistic:
-        if user_statistic.telegram_id:
-            message = template_message.substitute(
-                {key: getattr(user_statistic, attribute) for key, attribute in template_attribute_aliases.items()}
-            )
-            await send_message(
-                bot=context.bot, chat_id=user_statistic.telegram_id, text=message, reply_markup=reply_markup
-            )

--- a/src/core/send_message.py
+++ b/src/core/send_message.py
@@ -17,13 +17,7 @@ async def send_message(
     text: str,
     reply_markup: Optional[ReplyKeyboardMarkup | InlineKeyboardMarkup] = None,
 ) -> bool:
-    """
-    Send simple text message.
-    :param bot: Bot
-    :param chat_id: int
-    :param text: str
-    :param reply_markup: ReplyKeyboardMarkup | None
-    """
+    """Send simple text message."""
     try:
         await bot.send_message(chat_id, text, ParseMode.MARKDOWN_V2, reply_markup=reply_markup)
         return True
@@ -39,12 +33,7 @@ async def edit_message(
     new_text: str,
     reply_markup: Optional[ReplyKeyboardMarkup | InlineKeyboardMarkup] = None,
 ) -> bool:
-    """
-    Edit text message.
-    :param update: Update
-    :param new_text: str
-    :param reply_markup: ReplyKeyboardMarkup | None
-    """
+    """Edit text message."""
     try:
         await update.callback_query.edit_message_text(new_text, ParseMode.MARKDOWN_V2, reply_markup=reply_markup)
         return True
@@ -58,12 +47,7 @@ async def reply_message(
     text: str,
     reply_markup: Optional[ReplyKeyboardMarkup | InlineKeyboardMarkup] = None,
 ) -> bool:
-    """
-    Reply on the message.
-    :param update: Update
-    :param text: str
-    :param reply_markup: ReplyKeyboardMarkup | None
-    """
+    """Reply on the message."""
     try:
         message = update.callback_query.message if update.message is None else update.message
         await message.reply_markdown(text, reply_markup=reply_markup)

--- a/src/core/send_message.py
+++ b/src/core/send_message.py
@@ -25,12 +25,7 @@ async def send_message(
     :param reply_markup: ReplyKeyboardMarkup | None
     """
     try:
-        await bot.send_message(
-            chat_id=chat_id,
-            text=text,
-            parse_mode=ParseMode.MARKDOWN,
-            reply_markup=reply_markup,
-        )
+        await bot.send_message(chat_id, text, ParseMode.MARKDOWN_V2, reply_markup=reply_markup)
         return True
     except Forbidden:
         logger.warning("Forbidden: bot was blocked by the user: %s", chat_id)
@@ -51,11 +46,7 @@ async def edit_message(
     :param reply_markup: ReplyKeyboardMarkup | None
     """
     try:
-        await update.callback_query.edit_message_text(
-            text=new_text,
-            parse_mode=ParseMode.MARKDOWN,
-            reply_markup=reply_markup,
-        )
+        await update.callback_query.edit_message_text(new_text, ParseMode.MARKDOWN_V2, reply_markup=reply_markup)
         return True
     except TelegramError:
         logger.exception("The error editing the message to the chat: %d", update.effective_chat.id)
@@ -75,7 +66,7 @@ async def reply_message(
     """
     try:
         message = update.callback_query.message if update.message is None else update.message
-        await message.reply_markdown(text=text, reply_markup=reply_markup)
+        await message.reply_markdown(text, reply_markup=reply_markup)
         return True
     except TelegramError:
         logger.exception("The error reply on the message to the chat: %d", update.effective_chat.id)

--- a/src/service/repeat_message.py
+++ b/src/service/repeat_message.py
@@ -19,14 +19,14 @@ async def repeat_message_after_1_hour_callback(update: Update, context: ContextT
     query = update.callback_query
     data = query.message
     context.job_queue.run_once(repeat_message_job, when=timedelta(hours=1), data=data, chat_id=query.message.chat.id)
-    await edit_message(update, data.text_markdown)
+    await edit_message(update, data.text_markdown_v2_urled)
     await query.answer()  # close progress bar in chat
 
 
 async def repeat_message_job(context: CallbackContext) -> None:
     """Repeat delayed message."""
     data = context.job.data
-    await send_message(context.bot, context.job.chat_id, data.text_markdown, data.reply_markup)
+    await send_message(context.bot, context.job.chat_id, data.text_markdown_v2_urled, data.reply_markup)
 
 
 repeat_after_one_hour_button = InlineKeyboardButton("🕑 Напомнить через час", callback_data=CALLBACK_REPEAT_COMMAND)


### PR DESCRIPTION
При получении уведомления о необходимости сформировать чек, если пользователь нажимал на кнопку - кнопки удалялись, но в сообщении появлялись обратные слеши `\` перед `-` и `!`