### PR TITLE
Исправлена обработка зоны UTC и все связанные с этим баги

### DIFF
--- a/src/get_timezone.py
+++ b/src/get_timezone.py
@@ -18,7 +18,7 @@ def get_timezone_utc_format(txt_pattern: Optional[str]) -> Optional[datetime.tim
     """Returns datetime.timezone based on string in format UTC+00:00 or NONE"""
     if txt_pattern is None:
         return None
-    tz_pattern = r"^(UTC)?(?P<sign>[-+]?)(?P<hours>(0?[0-9])|(1[0-2]))?(:(?P<minutes>0{1,2}|30|45))?$"
+    tz_pattern = r"^(UTC)?(?P<sign>[-+]?)(?P<hours>(0?[0-9])|(1[0-4]))?(:(?P<minutes>0{1,2}|30|45))?$"
     tz_result = re.search(tz_pattern, txt_pattern, flags=re.IGNORECASE)
     if tz_result is None:
         return None
@@ -31,6 +31,8 @@ def get_timezone_utc_format(txt_pattern: Optional[str]) -> Optional[datetime.tim
     tz_delta = datetime.timedelta(hours=hours, minutes=minutes)
     if tz_result.group("sign") in ("+", ""):
         return datetime.timezone(tz_delta)
+    if hours in [13, 14]:
+        return None
     return datetime.timezone(-tz_delta)
 
 

--- a/src/get_timezone.py
+++ b/src/get_timezone.py
@@ -18,15 +18,17 @@ def get_timezone_utc_format(txt_pattern: Optional[str]) -> Optional[datetime.tim
     """Returns datetime.timezone based on string in format UTC+00:00 or NONE"""
     if txt_pattern is None:
         return None
-    tz_pattern = r"^(UTC)?(?P<sign>[-+]?)(?P<hours>(0?[0-9])|(1[0-4]))(:(?P<minutes>0{1,2}|30|45))?$"
+    tz_pattern = r"^(UTC)?(?P<sign>[-+]?)(?P<hours>(0?[0-9])|(1[0-2]))?(:(?P<minutes>0{1,2}|30|45))?$"
     tz_result = re.search(tz_pattern, txt_pattern, flags=re.IGNORECASE)
     if tz_result is None:
         return None
 
+    hours = tz_result.group("hours")
+    hours = 0 if hours is None else int(hours)
     minutes = tz_result.group("minutes")
     minutes = 0 if minutes is None else int(minutes)
 
-    tz_delta = datetime.timedelta(hours=int(tz_result.group("hours")), minutes=minutes)
+    tz_delta = datetime.timedelta(hours=hours, minutes=minutes)
     if tz_result.group("sign") in ("+", ""):
         return datetime.timezone(tz_delta)
     return datetime.timezone(-tz_delta)
@@ -56,7 +58,7 @@ async def get_timezone_from_location(update: Update, context: CallbackContext):
     if user_timezone is None:
         return None
     time_zone = pytz.timezone(user_timezone).localize(datetime.datetime.now()).strftime("%z")
-    text_utc = TIME_ZONE + time_zone[:3] + time_zone[3:]
+    text_utc = TIME_ZONE + time_zone[:3] + ":" + time_zone[3:]
     await set_timezone(update.effective_chat.id, text_utc, context)
     return text_utc
 


### PR DESCRIPTION
Fixed processing of the UTC timezone; corrected message when the timezone is set via location.
Notion: 
[[Баг] Не приходят уведомления, связанные с таймзонами, при выставленной UTC +00:00](https://www.notion.so/UTC-00-00-beb661e287fa4ddca29d59bca83a554a)
[[Баг] При расшаривании геолокации выходит сообщение "Вы настроили часовой пояс UTC +0300 ..." - не хватает двоеточия](https://www.notion.so/UTC-0300-7fa8938a32664d2f8c9d574df19b2bee)
[[Баг] Можно выставить таймзоны UTC -13 и UTC -14](https://www.notion.so/UTC-13-UTC-14-6768f39bd4bf4b08bfad9c693627602a)
[[Баг] При выставлении UTC +00:00 неверно отображается текущая таймзона в строке меню "Настроить часовой пояс(сейчас UTC XX:XX). Вместо 00:00 там таймзона, которая была выставлена до этого](https://www.notion.so/UTC-00-00-UTC-XX-3069ab84e68a4a19af1cd36e46fd7486)